### PR TITLE
Allow to configure caching.

### DIFF
--- a/src/Phalcon/Doctrine/DI/DoctrineOrmExtension.php
+++ b/src/Phalcon/Doctrine/DI/DoctrineOrmExtension.php
@@ -135,7 +135,7 @@ class DoctrineOrmExtension
 		}
 
 		if (!array_key_exists($driver, $this->cacheDriverClasses)) {
-			throw new InvalidArgumentException(sprintf('Unknown cache type specified: %s.', $driver));
+			throw new InvalidArgumentException(sprintf('The `%s` cache driver not supported.', $driver));
 		}
 
 		$className = $this->cacheDriverClasses[$driver];

--- a/src/Phalcon/Doctrine/DI/DoctrineOrmExtension.php
+++ b/src/Phalcon/Doctrine/DI/DoctrineOrmExtension.php
@@ -68,7 +68,12 @@ class DoctrineOrmExtension
 	 */
 	public $cacheDriverClasses = [
 		'default' => 'Doctrine\Common\Cache\ArrayCache',
+		'apc' => 'Doctrine\Common\Cache\ApcCache',
+		'apcu' => 'Doctrine\Common\Cache\ApcuCache',
 		'array' => 'Doctrine\Common\Cache\ArrayCache',
+		'memcache' => 'Kdyby\DoctrineCache\MemcacheCache',
+		'memcached' => 'Kdyby\DoctrineCache\MemcachedCache',
+		'redis' => 'Kdyby\DoctrineCache\RedisCache',
 	];
 
 	/**


### PR DESCRIPTION
This pull request enables automatically `ArrayCache` as a default cache provider for all caching mechanism Doctrine's having.

It also allows to override the default cache provider by one of supported drivers:

- apc
- apcu
- memcache
- memcached
- redis